### PR TITLE
Modifies start script to use /opt/lab location of istio content

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,7 +5,7 @@ oc cluster up --public-hostname="$LC_MYIP" \
   --host-data-dir=/var/lib/origin/openshift.local.data
 
 #curl -L https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-osx.tar.gz | tar xz
-cd istio-0.6.0
+cd /opt/lab/istio-0.6.0
 oc login -u system:admin
 oc adm policy add-cluster-role-to-user cluster-admin developer
 oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system


### PR DESCRIPTION
I updated the vm image to have istio and the lab content in /opt/lab

The start script needed to know this.