### PR TITLE
Update intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,105 @@
-# Red Hat Summit 2018: <br/>Getting Hands On With Istio on OpenShift
+# Red Hat Summit 2018: 
+# Getting Hands On With Istio on OpenShift
 
-Lab guides for the Getting Hands On With Istio on OpenShift at Red Hat Summit 2018
+![Istio Logo]({% image_path istio-logo.png %})
 
 ## Purpose
 
-As microservices-based applications become more prevalent, both the number of and complexity of
-their interactions increases. Up until now much of the burden of managing these complex
-microservices interactions has been placed on the application developer, with different or
-non-existent support for microservice concepts depending on language and framework.
+As microservices-based applications become more prevalent, both the number of
+and complexity of their interactions increases. Up until now much of the burden
+of managing these complex microservices interactions has been placed on the
+application developer, with different or non-existent support for microservice
+concepts depending on language and framework.
 
-The service mesh concept pushes this responsibility to the infrastructure, with features for
-traffic management, distributed tracing and observability, policy enforcement, and
-service/identity security, freeing the developer to focus on business value. In this hands-on
-session you will learn how to apply some of these features to a simple polyglot microservices
-application running on top of OpenShift using Istio, an open platform to connect, manage, and
-secure microservices.
+The service mesh concept pushes this responsibility to the infrastructure, with
+features for traffic management, distributed tracing and observability, policy
+enforcement, and service/identity security, freeing the developer to focus on
+business value. In this hands-on session you will learn how to apply some of
+these features to a simple polyglot microservices application running on top of
+OpenShift using Istio, an open platform to connect, manage, and secure
+microservices.
 
+## Background
+
+Istio is an open platform to connect, manage, and secure microservices. Istio
+provides an easy way to create a network of deployed services with load
+balancing, service-to-service authentication, monitoring, and more, without
+requiring any changes in application code. OpenShift can automatically inject a
+special sidecar proxy throughout your environment to enable Istio management for
+your application. This proxy intercepts all network communication between your
+microservices microservices, and is configured and managed using Istio’s control
+plane functionality -- not your application code!
+
+### Fetch connect script
+
+First, open a terminal and run the following commands:
+
+~~~bash
+cd
+wget https://raw.githubusercontent.com/jamesfalkner/istio-lab-summit-2018/master/scripts/connect.sh
+~~~
+
+### Find your hostname
+
+In the browser, you had requested a lab environment. On that page, you were
+assigned a GUID (a 4-digit alphanumeric string). For example, `xxxx`.
+
+### Execute connect script
+
+To connect to your provisioned lab machine, run the following command:
+**MAKE SURE THAT YOU SUBSTITUTE `xxxx` FOR THE GUID THAT YOU WERE ASSIGNED**
+
+~~~bash
+cd
+bash connect.sh openshift-xxxx.rhpds.opentlc.com
+~~~
+
+Make sure you type _yes_ to complete the SSH connection.
+
+Once connected, your lab machine has several environment variables pre-defined,
+and has Istio added to your `$PATH`. You can confirm this is set correctly:
+
+~~~bash
+echo Istio Home: $ISTIO_HOME && \
+echo Istio Lab Content: $ISTIO_LAB_HOME && \
+echo Istio Lab Project Name: $ISTIO_LAB_PROJECT && \
+echo Path: $PATH
+~~~
+
+### Start OpenShift and install Istio
+All of the exercises in this lab will be performed as the `root` system user.
+First, escalate your privileges using the following `sudo` command: 
+**MAKE SURE THAT YOU EXECUTE THE SUDO COMMAND EXACTLY OR YOUR ENVIRONMENT
+VARIABLES WILL NOT PROPAGATE CORRECTLY**
+
+~~~bash
+sudo -E -i
+~~~
+
+Then, execute the following two commands which will start the local OpenShift
+environment and install Istio into it:
+
+~~~bash
+cd $ISTIO_LAB_HOME
+./scripts/start.sh
+~~~
+
+The start script will then output a URL for you to visit:
+
+~~~
+--------------------
+Setup complete. Open the Lab Instructions in your browser: http://istio-workshop-guides.aa.bb.cc.dd.xip.io
+--------------------
+~~~
+
+This is the URL for your customized lab guide that you will use for the rest of
+the lab. Please open that URL in your browser and continue from there.
+
+# Using this lab content elsewhere
 ## Deploy On OpenShift
 
-You can deploy the lab guides as a container image anywhere but most conveniently, you can deploy it on OpenShift Online or other OpenShift flavours:
+You can deploy the lab guides as a container image anywhere but most
+conveniently, you can deploy it on OpenShift Online or other OpenShift flavours:
 
 ```
 oc new-project guides
@@ -33,16 +114,20 @@ oc new-app osevg/workshopper --name=istio-workshop \
 oc expose svc/istio-workshop
 ```
 
-Replace `OPENSHIFT_MASTER` with the URL to your working OpenShift master (e.g. `http://127.0.0.1:8443`), `APPS_SUFFIX` with your
-default routing suffix (e.g. `apps.127.0.0.1.nip.io`), and `ISTIO_LAB_HOSTNAME` with the public hostname
-of your machine. These variables are used to subsitute values in the markdown content files.
+Replace `OPENSHIFT_MASTER` with the URL to the console of your working OpenShift
+environment (e.g.  `http://128.0.0.1:8443`), `APPS_SUFFIX` with your default
+routing suffix (e.g.  `apps.127.0.0.1.nip.io`), and `ISTIO_LAB_HOSTNAME` with
+the public hostname of your machine. These variables are used to subsitute
+values in the markdown content files.
 
 The guides can then be accessed at `http://istio-workshop-guides.$APPS_SUFFIX`.
 
 The lab content (`.md` files) will be pulled from the GitHub when users access the guides in
 their browser.
 
-Note that the workshop variables can be overriden via specifying environment variables on the container itself e.g. the `JAVA_APP` env var in the above command
+Note that the workshop variables can be overriden via specifying environment
+variables on the container itself e.g. the `JAVA_APP` env var in the above
+command
 
 ## Test Locally with Docker
 
@@ -57,10 +142,13 @@ docker run -p 8080:8080 -v $(pwd):/app-data \
               osevg/workshopper:latest
 ```
 
-Replace `OPENSHIFT_MASTER` with the URL to your working OpenShift master (e.g. `http://127.0.0.1:8443`), `APPS_SUFFIX` with your
-default routing suffix (e.g. `apps.127.0.0.1.nip.io`), and `ISTIO_LAB_HOSTNAME` with the public hostname
-of your machine. These variables are used to subsitute values in the markdown content files.
+Replace `OPENSHIFT_MASTER` with the URL to the console of your working OpenShift
+environment (e.g.  `http://128.0.0.1:8443`), `APPS_SUFFIX` with your default
+routing suffix (e.g.  `apps.127.0.0.1.nip.io`), and `ISTIO_LAB_HOSTNAME` with
+the public hostname of your machine. These variables are used to subsitute
+values in the markdown content files.
 
-Go to http://localhost:8080 on your browser to see the rendered workshop content. You can modify the lab instructions
-and refresh the page to see the latest changes.
+Go to `http://localhost:8080` on your browser to see the rendered workshop
+content. You can modify the lab instructions and refresh the page to see the
+latest changes.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ assigned a GUID (a 4-digit alphanumeric string). For example, `xxxx`.
 ### Execute connect script
 
 To connect to your provisioned lab machine, run the following command:
+
 **MAKE SURE THAT YOU SUBSTITUTE `xxxx` FOR THE GUID THAT YOU WERE ASSIGNED**
 
 ~~~bash
@@ -69,6 +70,7 @@ echo Path: $PATH
 ### Start OpenShift and install Istio
 All of the exercises in this lab will be performed as the `root` system user.
 First, escalate your privileges using the following `sudo` command: 
+
 **MAKE SURE THAT YOU EXECUTE THE SUDO COMMAND EXACTLY OR YOUR ENVIRONMENT
 VARIABLES WILL NOT PROPAGATE CORRECTLY**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Red Hat Summit 2018: 
 # Getting Hands On With Istio on OpenShift
 
-![Istio Logo]({% image_path istio-logo.png %})
+![Istio Logo](instructions/images/istio-logo.png)
 
 ## Purpose
 

--- a/instructions/intro.md
+++ b/instructions/intro.md
@@ -1,60 +1,15 @@
-# Introduction and Setup
-
-![Istio Logo]({% image_path istio-logo.png %})
-
-Istio is an open platform to connect, manage, and secure microservices. Istio provides an easy way to create a network of deployed services with load balancing, service-to-service authentication, monitoring, and more, without requiring any changes in service code. You add Istio support to services by deploying a special sidecar proxy throughout your environment that intercepts all network communication between microservices, configured and managed using Istio’s control plane functionality.
-
-Follow the steps below to get started with this lab!
-
-### Fetch connect script
-
-First, open a terminal and run the following commands:
-
-~~~sh
-cd
-wget https://raw.githubusercontent.com/jamesfalkner/istio-lab-summit-2018/master/scripts/connect.sh
-~~~
-
-### Find your hostname
-
-Your hostname for this lab is `{{ISTIO_LAB_HOSTNAME}}`.
-
-### Execute connect script
-
-To connect to your provisioned lab machine, run the following command:
-
-~~~sh
-bash connect.sh {{ISTIO_LAB_HOSTNAME}} ~/.ssh/summit_lab_rsa
-~~~
-
-Your lab environment pre-defines several environment variables and adds Istio your `$PATH`. Confirm they
-are set correctly:
-
-~~~bash
-echo Istio Home: $ISTIO_HOME && \
-echo Istio Lab Content: $ISTIO_LAB_HOME && \
-echo Istio Lab Content: $ISTIO_LAB_HOME && \
-echo Istio Lab Project Name: $ISTIO_LAB_PROJECT && \
-echo Path: $PATH
-~~~
-
-### Start OpenShift and install Istio
-
-~~~sh
-sudo -E -i
-cd $ISTIO_LAB_HOME
-./scripts/start.sh
-~~~
-
-After the start script completes, you are ready to move on to the first exercise! Good luck!
+# This is the lab guide
+Congratulations! If you've gotten this far, you are ready to move on to the
+first real exercise! Good luck!
 
 ### Opening more Terminals
 
 If you need to open up more terminal windows during the lab, you'll again need
-to use `ssh` to connect to the environment before executing commands in the exercises:
+to use the `connect.sh` script to connect to the environment before executing
+commands in the exercises:
 
 ~~~bash
-bash connect.sh {{ISTIO_LAB_HOSTNAME}} ~/.ssh/summit_lab_rsa
+bash connect.sh {{ISTIO_LAB_HOSTNAME}}
 ~~~
 
 Then:
@@ -64,6 +19,5 @@ sudo -E -i
 cd $ISTIO_LAB_HOME
 ~~~
 
-## Congratulations!
-
-In the next step we'll use Istio to intelligently route traffic. Click **Go To Next Module** to continue!
+In the first lab you'll use Istio to intelligently route traffic. Click **Go To
+Next Module** to continue!


### PR DESCRIPTION
The README was tweaked to be the initial landing page for students and to provide the initial connection information. We had moved to workshopper running in each student's environment. That meant the "intro" lab wasn't actually available until after the student had connected to their instance and started OpenShift.

Fixes #24 